### PR TITLE
fix docker references with uppercase chars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR ${src}
 
 ####
 # Creates a Docker image with the static binary to run the app.
-FROM src as build_app
+FROM src AS build-app
 
 RUN CGO_ENABLED=0 go build \
     -o /bin/build \
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 go build \
 
 ####
 # Creates a Docker image with the scrapme helper binary for the e2e tests.
-FROM src as build_scrapeme
+FROM src AS build-scrapeme
 
 RUN CGO_ENABLED=0 go build \
     -o /bin/build \
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 go build \
 ####
 # Creates an empty image with certs and other things required
 # to run Go static binaries.
-FROM scratch as withCerts
+FROM scratch AS with-certs
 
 COPY --from=src \
     /etc/ssl/certs/ca-certificates.crt \
@@ -39,15 +39,15 @@ COPY --from=src \
 
 ####
 # Creates a single layer image to run the app.
-FROM withCerts as run_app
+FROM with-certs AS run-app
 
-COPY --from=build_app /bin/build /bin/runme
+COPY --from=build-app /bin/build /bin/runme
 ENTRYPOINT ["/bin/runme"]
 
 ####
 # Creates a single layer image to run the scrapeme helper for the e2e
 # tests.
-FROM scratch as run_scrapeme
+FROM scratch AS run-scrapeme
 
-COPY --from=build_scrapeme /bin/build /bin/runme
+COPY --from=build-scrapeme /bin/build /bin/runme
 ENTRYPOINT ["/bin/runme"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,48 @@
 ARG project=sputnik-popularity
 ARG src=/tmp/${project}
 
-####
-# Creates a Docker image with the sources.
-FROM golang:1.15.1-buster AS src
+# Creates a Docker image with the project dependencies installed in the
+# Go cache.
+FROM golang:1.15.1-buster AS with-deps
 ARG src
-
-COPY . ${src}
 WORKDIR ${src}
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
 
-####
+# Creates a Docker image with the sources.
+FROM with-deps AS with-sources
+COPY . .
+
 # Creates a Docker image with the static binary to run the app.
-FROM src AS build-app
-
+FROM with-sources AS build-app
 RUN CGO_ENABLED=0 go build \
     -o /bin/build \
     -ldflags '-extldflags "-static"' \
     -tags timetzdata \
     ./app/cmd/sputnik-popularity
 
-####
 # Creates a Docker image with the scrapme helper binary for the e2e tests.
-FROM src AS build-scrapeme
-
+FROM with-sources AS build-scrapeme
 RUN CGO_ENABLED=0 go build \
     -o /bin/build \
     -ldflags '-extldflags "-static"' \
     ./tests/e2e/scrapeme
 
-####
 # Creates an empty image with certs and other things required
 # to run Go static binaries.
 FROM scratch AS with-certs
-
-COPY --from=src \
+COPY --from=golang:1.15.1-buster \
     /etc/ssl/certs/ca-certificates.crt \
     /etc/ssl/certs/ca-certificates.crt
 
-####
 # Creates a single layer image to run the app.
 FROM with-certs AS run-app
-
 COPY --from=build-app /bin/build /bin/runme
 ENTRYPOINT ["/bin/runme"]
 
-####
 # Creates a single layer image to run the scrapeme helper for the e2e
 # tests.
 FROM scratch AS run-scrapeme
-
 COPY --from=build-scrapeme /bin/build /bin/runme
 ENTRYPOINT ["/bin/runme"]

--- a/debug/docker-compose.yml
+++ b/debug/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   scrapeme:
     build:
       context: ../.
-      target: run_scrapeme
+      target: run-scrapeme
     ports:
       - 8080
     environment:
@@ -17,7 +17,7 @@ services:
   sputnik-popularity:
     build:
       context: ../.
-      target: run_app
+      target: run-app
     ports:
       - "8080:8080"
     depends_on:

--- a/makefile
+++ b/makefile
@@ -13,15 +13,15 @@ unit:
 	go test ./... -cover -race
 
 .PHONY: clean
-clean: integration_clean e2e_clean
+clean: integration-clean e2e-clean
 
 .PHONY: integration
-integration: integration_test integration_clean
+integration: integration-test integration-clean
 
-integration_test: dir := tests/integration
-integration_test: project := integration
-integration_test: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
-integration_test:
+integration-test: dir := tests/integration
+integration-test: project := integration
+integration-test: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
+integration-test:
 	docker-compose $(dc-flags) build
 	docker-compose $(dc-flags) up \
 		--force-recreate \
@@ -35,21 +35,21 @@ integration_test:
 		fi
 	docker-compose $(dc-flags) logs tester
 
-.PHONY: integration_clean
-integration_clean: dir := tests/integration
-integration_clean: project := integration
-integration_clean: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
-integration_clean:
+.PHONY: integration-clean
+integration-clean: dir := tests/integration
+integration-clean: project := integration
+integration-clean: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
+integration-clean:
 	docker-compose $(dc-flags) rm -v --stop --force
 
 .PHONY: e2e
-e2e: e2e_test e2e_clean
+e2e: e2e-test e2e-clean
 
-.PHONY: e2e_test
-e2e_test: dir := tests/e2e
-e2e_test: project := e2e
-e2e_test: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
-e2e_test:
+.PHONY: e2e-test
+e2e-test: dir := tests/e2e
+e2e-test: project := e2e
+e2e-test: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
+e2e-test:
 	docker-compose $(dc-flags) build
 	docker-compose $(dc-flags) up \
 		--force-recreate \
@@ -63,13 +63,13 @@ e2e_test:
 		fi
 	docker-compose $(dc-flags) logs tester
 
-.PHONY: e2e_clean
-e2e_clean: dir := tests/e2e
-e2e_clean: project := e2e
-e2e_clean: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
-e2e_clean:
+.PHONY: e2e-clean
+e2e-clean: dir := tests/e2e
+e2e-clean: project := e2e
+e2e-clean: dc-flags := -p $(project) -f $(dir)/docker-compose.yml
+e2e-clean:
 	docker-compose $(dc-flags) rm -v --stop --force
 
-.PHONY: docker_image
-docker_image:
-	docker build -t sputnik --target=run_app .
+.PHONY: docker-image
+docker-image:
+	docker build -t sputnik --target=run-app .

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   tester:
     build:
       context: ../..
-      target: src
+      target: with-sources
     entrypoint: ["go", "test", "-tags", "e2e", "./tests/e2e/..."]
     depends_on:
       - influxdb

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -7,14 +7,14 @@ services:
   scrapeme:
     build:
       context: ../..
-      target: run_scrapeme
+      target: run-scrapeme
     environment:
       - SCRAPEME_PORT=8080
 
   sputnik-popularity:
     build:
       context: ../..
-      target: run_app
+      target: run-app
     depends_on:
       - influxdb
       - scrapeme

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   tester:
     build:
       context: ../..
-      target: src
+      target: with-sources
     entrypoint: ["go", "test", "-tags", "integration", "-cover", "-race", "./app/influx"]
     depends_on:
       - influxdb


### PR DESCRIPTION
Docker references cannot have uppercase characters (withCerts). Regular
docker doesn't mind about that, but when you use docker buildkit, it
will complain.

This patch fixes that and rename all docker references and makefile
targets to use '-' instead of '_' for consistency.